### PR TITLE
Revenue considers discounts

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,6 +1,6 @@
 class BulkDiscountsController < ApplicationController
   def index
-    @bulk_discounts = BulkDiscount.for(params[:merchant_id])
+    @bulk_discounts = BulkDiscount.for_merchant(params[:merchant_id])
     @merchant_id = params[:merchant_id]
   end
 

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,6 +8,6 @@ class InvoicesController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
     invoice_id = params[:id]
     @invoice = Invoice.find(invoice_id)
-    @invoice_items = InvoiceItem.find_all_by_invoice(invoice_id)
+    @invoice_items = InvoiceItem.for_invoice_include_discount_id(invoice_id) # find_all_by_invoice(invoice_id)
   end
 end

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -5,7 +5,28 @@ class BulkDiscount < ApplicationRecord
   validates :threshold, presence: true, numericality: { only_integer: true }
   validates :percent_discount, presence: true, numericality: { only_integer: true }
 
-  def self.for(merchant_id)
+  def self.for_merchant(merchant_id)
     where(merchant_id: merchant_id)
+  end
+
+  def self.for_merchant_quantity(merchant_id, quantity)
+    raw_discount = where('threshold <= ?', quantity)
+      .where(merchant_id: merchant_id)
+      .select(:percent_discount)
+      .order(percent_discount: :desc)
+      .limit(1)
+      .pluck(:percent_discount)
+      .first
+
+    percent_for(raw_discount)
+  end
+
+  private
+  def self.percent_for(raw_discount)
+    if raw_discount.nil?
+      0
+    else
+      raw_discount / 100.0
+    end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -25,13 +25,9 @@ class Invoice < ApplicationRecord
     invoice_items.pluck(Arel.sql("sum(invoice_items.quantity * invoice_items.unit_price) as total_revenue"))
   end
 
-  def total_revenue_with_discount
-    total_revenue = 0
+  def total_revenue_with_discounts
+    # TODO this is using ruby, but should be reworked to leverage the db?
     invoice_items.sum(&:revenue_including_discounts)
-    # each do |invoice_item|
-    #   total_revenue += invoice_item.revenue_including_discounts
-    # end
-    # total_revenue
   end
 
   def invoice_item_revenue(invoice_item_quantity, invoice_item_price, percent_discount)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -26,34 +26,21 @@ class Invoice < ApplicationRecord
   end
 
   def total_revenue_with_discount
-
+    total_revenue = 0
+    invoice_items.sum(&:revenue_including_discounts)
+    # each do |invoice_item|
+    #   total_revenue += invoice_item.revenue_including_discounts
+    # end
+    # total_revenue
   end
 
-  def foo_total_revenue_with_discount
-    # slim_invoice_items = invoice_items.select(:id, :quantity, :unit_price)
-    # discounts = BulkDiscount.all_discount_threshold_desc
+  def invoice_item_revenue(invoice_item_quantity, invoice_item_price, percent_discount)
+    tmp_revenue = (invoice_item_quantity * invoice_item_price)
 
-    # total_revenue = 0
-    # slim_invoice_items.each do |invoice_item|
-    #   # Calc revenue
-    #   tmp_revenue = invoice_item.quantity * invoice_item.unit_price
-
-    #   # Find if a discount applies
-    #   discount_percent = 0
-    #   discounts.each do |discount|
-    #     if discount.threshold <= invoice_item.quantity
-    #       discount_percent = discount.percent_discount
-    #       break
-    #     else
-    #       next
-    #     end
-    #   end
-
-    #   # If so, apply discount to revenue
-    #   tmp_revenue -= (tmp_revenue * (discount_percent/100))
-
-    #   # Add res to accumulator
-    #   total_revenue += tmp_revenue
-    # end
+    if percent_discount.nil?
+      tmp_revenue
+    else
+      tmp_revenue - (tmp_revenue * (percent_discount / 100))
+    end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -24,4 +24,36 @@ class Invoice < ApplicationRecord
   def total_revenue
     invoice_items.pluck(Arel.sql("sum(invoice_items.quantity * invoice_items.unit_price) as total_revenue"))
   end
+
+  def total_revenue_with_discount
+
+  end
+
+  def foo_total_revenue_with_discount
+    # slim_invoice_items = invoice_items.select(:id, :quantity, :unit_price)
+    # discounts = BulkDiscount.all_discount_threshold_desc
+
+    # total_revenue = 0
+    # slim_invoice_items.each do |invoice_item|
+    #   # Calc revenue
+    #   tmp_revenue = invoice_item.quantity * invoice_item.unit_price
+
+    #   # Find if a discount applies
+    #   discount_percent = 0
+    #   discounts.each do |discount|
+    #     if discount.threshold <= invoice_item.quantity
+    #       discount_percent = discount.percent_discount
+    #       break
+    #     else
+    #       next
+    #     end
+    #   end
+
+    #   # If so, apply discount to revenue
+    #   tmp_revenue -= (tmp_revenue * (discount_percent/100))
+
+    #   # Add res to accumulator
+    #   total_revenue += tmp_revenue
+    # end
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -15,7 +15,6 @@ class InvoiceItem < ApplicationRecord
   end
 
   def self.for_invoice_include_discount_id(invoice_id)
-    # TODO is this possible?
     discount_id_sql = Arel.sql(%{
       SELECT id
       FROM bulk_discounts
@@ -24,7 +23,7 @@ class InvoiceItem < ApplicationRecord
       LIMIT 1
     }.squish)
 
-    r = joins(:item)
+    joins(:item)
       .select("invoice_items.*, (#{discount_id_sql}) AS bulk_discount_id")
       .where(invoice_id: invoice_id)
   end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -9,7 +9,7 @@ class InvoiceItem < ApplicationRecord
     .find_by(invoice_id: invoiceid, item_id: itemid)
     .quantity
   end
-  
+
   def self.find_all_by_invoice(invoice_id)
     where(invoice_id: invoice_id)
   end
@@ -20,5 +20,12 @@ class InvoiceItem < ApplicationRecord
 
   def invoice_date
     invoice.created_at_view_format
+  end
+
+  def revenue_including_discounts
+    percent_discount = BulkDiscount.for_merchant_quantity(item.merchant_id, quantity)
+    tmp_revenue = (quantity * unit_price)
+
+    return tmp_revenue - (tmp_revenue * percent_discount)
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -14,6 +14,21 @@ class InvoiceItem < ApplicationRecord
     where(invoice_id: invoice_id)
   end
 
+  def self.for_invoice_include_discount_id(invoice_id)
+    # TODO is this possible?
+    discount_id_sql = Arel.sql(%{
+      SELECT id
+      FROM bulk_discounts
+      WHERE items.merchant_id = bulk_discounts.merchant_id AND bulk_discounts.threshold <= invoice_items.quantity
+      ORDER BY bulk_discounts.percent_discount DESC
+      LIMIT 1
+    }.squish)
+
+    r = joins(:item)
+      .select("invoice_items.*, (#{discount_id_sql}) AS bulk_discount_id")
+      .where(invoice_id: invoice_id)
+  end
+
   def item_name
     item.name
   end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -4,6 +4,7 @@
   <p>Status: <%= @invoice.status_view_format %></p>
   <p>Date Created: <%= @invoice.created_at_view_format %></p>
   <p>Total Revenue: <%= number_to_currency((@invoice.total_revenue[0])) %></p>
+  <p>Total Revenue With Discounts: <%= number_to_currency((@invoice.total_revenue_with_discounts)) %></p>
 </section>
 
 <section id='invoice_status_update'>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -2,6 +2,7 @@
 <h3>Status: <%= @invoice.status %></h3>
 <h3>Created on: <%= @invoice.created_at_view_format %></h3>
 <h3>Total Revenue: $<%= '%.2f' % @invoice.total_revenue %></h3>
+<h3>Total Revenue With Discounts: $<%= '%.2f' % @invoice.total_revenue_with_discounts %></h3>
 
 <h2>Customer:</h2>
 <p><%= @invoice.customer_full_name %></p>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -12,7 +12,11 @@
     <section id="invoice-item-<%= invoice_item.item.id %>">
       <p>Name: <%= invoice_item.item_name %></p>
       <p>Quantity: <%= invoice_item.quantity %></p>
-      <p>Sold For: $<%= '%.2f' % invoice_item.unit_price %></p>
+      <p>Sold For: $<%= '%.2f' % invoice_item.unit_price %>
+        <% if invoice_item.bulk_discount_id %>
+            | <%= link_to 'Applied Discount', merchant_bulk_discount_path(@merchant, invoice_item.bulk_discount_id) %>
+        <% end %>
+      </p>
       <p>Status: <%= invoice_item.status_view_format %></p>
 
       <%= form_with url: merchant_invoice_item_path(@merchant, invoice_item), method: :patch, params: { status: :status }, local: true do |f|%>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe 'Admin invoices show page' do
 
         expect(page).to have_content("#{'%.2f' % @invoice_1.total_revenue}")
       end
+      it 'also shows total revenue with discounts' do
+        create(:bulk_discount, threshold: 2, percent_discount: 50, merchant: @merchant)
+        visit admin_invoice_path(@invoice_1)
+
+        expect(page).to have_content("#{'%.2f' % @invoice_1.total_revenue_with_discounts}")
+      end
     end
 
     describe'displays customer information' do
@@ -59,7 +65,7 @@ RSpec.describe 'Admin invoices show page' do
       end
       it 'can pick a new status for the Invoice and see it updated on the Admin Invoice Show Page' do
         visit admin_invoice_path(@invoice_2)
-        
+
         select 'completed', from: 'Status'
         click_on('Update Invoice')
 
@@ -82,12 +88,13 @@ RSpec.describe 'Admin invoices show page' do
   end
 
   def setup
+    @merchant = create(:merchant)
     @customer_1 = create(:customer)
     @invoice_1 = create(:invoice, customer_id: @customer_1.id)
-    @item_1 = create(:item)
+    @item_1 = create(:item, merchant: @merchant)
     @item_2 = create(:item)
-    @item_3 = create(:item)
-    @invoice_item_1 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 2, unit_price: 1.00)
+    @item_3 = create(:item, merchant: @merchant)
+    @invoice_item_1 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 1, unit_price: 2.00)
     @invoice_item_2 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 2, unit_price: 5.00)
     @invoice_item_2 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_3.id, quantity: 2, unit_price: 5.00)
     @invoice_2 = create(:invoice, status: :in_progress)

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -110,5 +110,28 @@ RSpec.describe 'As a merchant' do
         expect(page).to have_select('status', selected: 'pending')
       end
     end
+
+    describe 'invoice items link to discount show page' do
+      it 'shows the link when a discount is applied' do
+        discount = create(:bulk_discount, threshold: 8, percent_discount: 50, merchant: @merchant_1)
+        visit merchant_invoice_path(@merchant_1, @invoice_3)
+
+        within "#invoice-item-#{@item_1.id}" do
+          expect(page).to have_link('Applied Discount')
+          click_link('Applied Discount')
+        end
+
+        expect(current_path).to eq(merchant_bulk_discount_path(@merchant_1, discount))
+      end
+
+      it 'does not show a link when there is no discount' do
+        discount = create(:bulk_discount, threshold: 8, percent_discount: 50, merchant: @merchant_1)
+        visit merchant_invoice_path(@merchant_1, @invoice_3)
+
+        within "#invoice-item-#{@item_3.id}" do
+          expect(page).to_not have_link('Applied Discount')
+        end
+      end
+    end
   end
 end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe 'As a merchant' do
       visit merchant_invoice_path(@merchant_1, @invoice_1)
 
       total_revenue = "Total Revenue: $#{'%.2f' % @invoice_1.total_revenue}"
-      require "pry"; binding.pry
 
       expect(page).to have_content(total_revenue)
     end

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -14,12 +14,18 @@ RSpec.describe 'As a merchant' do
     @invoice_1 = create(:invoice, customer_id: @customer_1.id)
     @invoice_2 = create(:invoice, customer_id: @customer_2.id)
 
+
     @invoice_item_1 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_1.id, status: :pending)
     @invoice_item_2 = create(:invoice_item, invoice_id: @invoice_2.id, item_id: @item_2.id, status: :packaged)
     @invoice_item_3 = create(:invoice_item, invoice_id: @invoice_1.id, item_id: @item_2.id, status: :pending)
+
+    @item_3 = create(:item, merchant_id: @merchant_1.id, unit_price: 1.00)
+    @invoice_3 = create(:invoice, customer_id: @customer_1.id)
+    @invoice_item_4 = create(:invoice_item, invoice_id: @invoice_3.id, item_id: @item_1.id, quantity: 8, unit_price: 1)
+    @invoice_item_5 = create(:invoice_item, invoice_id: @invoice_3.id, item_id: @item_3.id, quantity: 6, unit_price: 1)
   end
 
-  describe 'When I visit my merchants invoice show page(/merchants/merchant_id/invoices/invoice_id)' do
+  describe 'When I visit my merchants invoice show page' do
     it 'I see information related to that invoice' do
       visit merchant_invoice_path(@merchant_1, @invoice_1)
 
@@ -67,6 +73,16 @@ RSpec.describe 'As a merchant' do
       visit merchant_invoice_path(@merchant_1, @invoice_1)
 
       total_revenue = "Total Revenue: $#{'%.2f' % @invoice_1.total_revenue}"
+      require "pry"; binding.pry
+
+      expect(page).to have_content(total_revenue)
+    end
+
+    it 'Also shows total revenue factoring in discounts' do
+      create(:bulk_discount, threshold: 8, percent_discount: 50, merchant: @merchant_1)
+      visit merchant_invoice_path(@merchant_1, @invoice_3)
+
+      total_revenue = "Total Revenue With Discounts: $10.00"
 
       expect(page).to have_content(total_revenue)
     end

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -14,44 +14,17 @@ RSpec.describe BulkDiscount, type: :model do
   end
 
   describe 'class methods' do
-    describe '::for' do
+    describe '::for_merchant' do
       it 'returns bulk discounts for merchant' do
         merchant = create(:merchant)
         expected = create_list(:bulk_discount, 3, merchant: merchant)
 
-        expect(BulkDiscount.for(merchant.id)).to eq(expected)
+        expect(BulkDiscount.for_merchant(merchant.id)).to eq(expected)
       end
 
       it 'returns an empty array if no discounts exist for merchant' do
         merchant = create(:merchant)
-        expect(BulkDiscount.for(merchant.id)).to eq([])
-      end
-    end
-
-    describe '::by_merchant_order_discount_threshold_desc' do
-      it "returns correctly sorted list of a merchant's discounts" do
-        merchant = create(:merchant)
-        discount_1 = create(:bulk_discount, threshold: 8, percent_discount: 30, merchant_id: merchant.id)
-        discount_2 = create(:bulk_discount, threshold: 6, percent_discount: 20, merchant_id: merchant.id)
-        discount_3 = create(:bulk_discount, threshold: 4, percent_discount: 10, merchant_id: merchant.id)
-
-        expected_order = [discount_1, discount_2, discount_3]
-        expect(BulkDiscount.by_merchant_order_discount_threshold_desc(merchant.id)).to eq(expected_order)
-      end
-
-      it 'returns correct order when unreachable discount percent exists' do
-        merchant = create(:merchant)
-        discount_1 = create(:bulk_discount, threshold: 8, percent_discount: 30, merchant_id: merchant.id)
-        discount_2 = create(:bulk_discount, threshold: 6, percent_discount: 10, merchant_id: merchant.id)
-        discount_3 = create(:bulk_discount, threshold: 4, percent_discount: 20, merchant_id: merchant.id)
-
-        expected_order = [discount_1, discount_3, discount_2]
-        expect(BulkDiscount.by_merchant_order_discount_threshold_desc(merchant.id)).to eq(expected_order)
-      end
-
-      it 'returns empty array when no discounts exist' do
-        merchant = create(:merchant)
-        expect(BulkDiscount.by_merchant_order_discount_threshold_desc(merchant.id)).to eq([])
+        expect(BulkDiscount.for_merchant(merchant.id)).to eq([])
       end
     end
 

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -27,5 +27,47 @@ RSpec.describe BulkDiscount, type: :model do
         expect(BulkDiscount.for(merchant.id)).to eq([])
       end
     end
+
+    describe '::by_merchant_order_discount_threshold_desc' do
+      it "returns correctly sorted list of a merchant's discounts" do
+        merchant = create(:merchant)
+        discount_1 = create(:bulk_discount, threshold: 8, percent_discount: 30, merchant_id: merchant.id)
+        discount_2 = create(:bulk_discount, threshold: 6, percent_discount: 20, merchant_id: merchant.id)
+        discount_3 = create(:bulk_discount, threshold: 4, percent_discount: 10, merchant_id: merchant.id)
+
+        expected_order = [discount_1, discount_2, discount_3]
+        expect(BulkDiscount.by_merchant_order_discount_threshold_desc(merchant.id)).to eq(expected_order)
+      end
+
+      it 'returns correct order when unreachable discount percent exists' do
+        merchant = create(:merchant)
+        discount_1 = create(:bulk_discount, threshold: 8, percent_discount: 30, merchant_id: merchant.id)
+        discount_2 = create(:bulk_discount, threshold: 6, percent_discount: 10, merchant_id: merchant.id)
+        discount_3 = create(:bulk_discount, threshold: 4, percent_discount: 20, merchant_id: merchant.id)
+
+        expected_order = [discount_1, discount_3, discount_2]
+        expect(BulkDiscount.by_merchant_order_discount_threshold_desc(merchant.id)).to eq(expected_order)
+      end
+
+      it 'returns empty array when no discounts exist' do
+        merchant = create(:merchant)
+        expect(BulkDiscount.by_merchant_order_discount_threshold_desc(merchant.id)).to eq([])
+      end
+    end
+
+    describe '::for_merchant_quantity' do
+      it 'returns 0 if there are no discounts' do
+        merchant = create(:merchant)
+        expect(BulkDiscount.for_merchant_quantity(merchant.id, 5)).to eq(0)
+      end
+
+      it 'sorts correctly' do
+        merchant = create(:merchant)
+        discount_1 = create(:bulk_discount, threshold: 10, percent_discount: 10, merchant_id: merchant.id)
+        discount_2 = create(:bulk_discount, threshold: 5, percent_discount: 50, merchant_id: merchant.id)
+
+        expect(BulkDiscount.for_merchant_quantity(merchant.id, 10)).to eq(0.5)
+      end
+    end
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -28,6 +28,42 @@ RSpec.describe InvoiceItem do
         expect(@invoice_item_2.unit_price_fix).to eq("5.00")
       end
     end
+
+    describe 'revenue_including_discounts' do
+      it 'calculates revenue when there are no discounts' do
+        @merchant = create(:merchant)
+        @item = create(:item, merchant_id: @merchant.id)
+        @discount = create(:bulk_discount, threshold: 10, percent_discount: 20, merchant_id: @merchant.id)
+        @invoice_item = create(:invoice_item, quantity: 5, unit_price: 2, item: @item)
+        # Result => no discounts applied
+        # Total Revenue => 10
+
+        expect(@invoice_item.revenue_including_discounts).to eq(10)
+      end
+
+      it 'calculates revenue when there is a discount' do
+        @merchant = create(:merchant)
+        @item = create(:item, merchant_id: @merchant.id)
+        @discount = create(:bulk_discount, threshold: 10, percent_discount: 50, merchant_id: @merchant.id)
+        @invoice_item = create(:invoice_item, quantity: 10, unit_price: 2, item: @item)
+        # Result => item_1 discounted 10%
+        # Total Revenue => 10
+
+        expect(@invoice_item.revenue_including_discounts).to eq(10)
+      end
+
+      it 'calculates revenue when there is an unreachable discount' do
+        @merchant = create(:merchant)
+        @item = create(:item, merchant_id: @merchant.id)
+        @discount_1 = create(:bulk_discount, threshold: 10, percent_discount: 10, merchant_id: @merchant.id)
+        @discount_2 = create(:bulk_discount, threshold: 5, percent_discount: 50, merchant_id: @merchant.id)
+        @invoice_item = create(:invoice_item, quantity: 10, unit_price: 2, item: @item)
+        # Result => item_1 discounted 50% (discount_2 is unreachable)
+        # Total Revenue => 10
+
+        expect(@invoice_item.revenue_including_discounts).to eq(10)
+      end
+    end
   end
 
   describe 'class methods' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -44,8 +44,10 @@ RSpec.describe Invoice do
     end
 
     describe '#total_revenue_with_discount' do
-      it 'test' do
-        # TODO
+      it 'can work when no discounts apply' do
+        setup_discount_example_1
+        expect(@invoice.total_revenue_with_discount).to eq('change to the number 15')
+        # TODO test the other examples
       end
     end
   end
@@ -101,13 +103,14 @@ RSpec.describe Invoice do
     @item_2 = create(:item, merchant_id: @merchant.id)
     @invoice = create(:invoice, customer_id: @customer.id)
     @invoice_item_1 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_1.id,
-                            status: InvoiceItem.statuses[:shipped], quantity: 5, unit_price: 1.00)
+                            status: InvoiceItem.statuses[:shipped], quantity: 5, unit_price: 2.00)
     @invoice_item_2 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_2.id,
                             status: InvoiceItem.statuses[:shipped], quantity: 5, unit_price: 1.00)
 
     @discount = create(:bulk_discount, threshold: 10, percent_discount: 20, merchant_id: @merchant.id)
 
     # Result => no discounts applied
+    # Total Revenue => 15
   end
 
   def setup_discount_example_2
@@ -121,9 +124,10 @@ RSpec.describe Invoice do
     @invoice_item_2 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_2.id,
                             status: InvoiceItem.statuses[:shipped], quantity: 5, unit_price: 1.00)
 
-    @discount = create(:bulk_discount, threshold: 10, percent_discount: 20, merchant_id: @merchant.id)
+    @discount = create(:bulk_discount, threshold: 10, percent_discount: 50, merchant_id: @merchant.id)
 
     # Result => item_1 discounted 20%
+    # Total Revenue => 10
   end
 
   def setup_discount_example_3
@@ -135,12 +139,13 @@ RSpec.describe Invoice do
     @invoice_item_1 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_1.id,
                             status: InvoiceItem.statuses[:shipped], quantity: 12, unit_price: 1.00)
     @invoice_item_2 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_2.id,
-                            status: InvoiceItem.statuses[:shipped], quantity: 15, unit_price: 1.00)
+                            status: InvoiceItem.statuses[:shipped], quantity: 16, unit_price: 1.00)
 
     @discount_1 = create(:bulk_discount, threshold: 10, percent_discount: 20, merchant_id: @merchant.id)
-    @discount_2 = create(:bulk_discount, threshold: 15, percent_discount: 30, merchant_id: @merchant.id)
+    @discount_2 = create(:bulk_discount, threshold: 15, percent_discount: 50, merchant_id: @merchant.id)
 
     # Result => item_1 discounted 20%, item_2 discounted 30%
+    # Total Revenue => 17.6
   end
 
   def setup_discount_example_4
@@ -152,12 +157,13 @@ RSpec.describe Invoice do
     @invoice_item_1 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_1.id,
                             status: InvoiceItem.statuses[:shipped], quantity: 12, unit_price: 1.00)
     @invoice_item_2 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_2.id,
-                            status: InvoiceItem.statuses[:shipped], quantity: 15, unit_price: 1.00)
+                            status: InvoiceItem.statuses[:shipped], quantity: 18, unit_price: 1.00)
 
-    @discount_1 = create(:bulk_discount, threshold: 10, percent_discount: 20, merchant_id: @merchant.id)
+    @discount_1 = create(:bulk_discount, threshold: 10, percent_discount: 50, merchant_id: @merchant.id)
     @discount_2 = create(:bulk_discount, threshold: 15, percent_discount: 15, merchant_id: @merchant.id)
 
-    # Result => item_1 discounted 20%, item_2 discounted 20% (discount_2 can never be applied)
+    # Result => item_1 discounted 50%, item_2 discounted 50% (discount_2 can never be applied)
+    # Total Revenue => 15
   end
 
   def setup_discount_example_5
@@ -175,10 +181,11 @@ RSpec.describe Invoice do
     @invoice_item_3 = create(:invoice_item, invoice_id: @invoice.id, item_id: @item_b1.id,
                             status: InvoiceItem.statuses[:shipped], quantity: 15, unit_price: 1.00)
 
-    @discount_1 = create(:bulk_discount, threshold: 10, percent_discount: 20, merchant_id: @merchant.id)
-    @discount_2 = create(:bulk_discount, threshold: 15, percent_discount: 30, merchant_id: @merchant.id)
+    @discount_1 = create(:bulk_discount, threshold: 10, percent_discount: 20, merchant_id: @merchant_a.id)
+    @discount_2 = create(:bulk_discount, threshold: 15, percent_discount: 30, merchant_id: @merchant_a.id)
     # Merchant B has no discounts
 
     # Result => item_a1 discounted 20%, item_a2 discounted 30%, item_b1 not discounted
+    # Total Revenue => 35.1
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -43,11 +43,34 @@ RSpec.describe Invoice do
       end
     end
 
-    describe '#total_revenue_with_discount' do
-      it 'can work when no discounts apply' do
+    describe '#total_revenue_with_discounts' do
+      it 'no valid discounts' do
         setup_discount_example_1
-        expect(@invoice.total_revenue_with_discount).to eq('change to the number 15')
-        # TODO test the other examples
+        expect(@invoice.total_revenue_with_discounts).to eq(15)
+      end
+
+      it '1 valid discount, applying to 1 of 2 invoice_items' do
+        # Total Revenue => 10
+        setup_discount_example_2
+        expect(@invoice.total_revenue_with_discounts).to eq(10)
+      end
+
+      it '2 valid discounts, each appying to an invoice_item' do
+        # Total Revenue => 17.6
+        setup_discount_example_3
+        expect(@invoice.total_revenue_with_discounts).to eq(17.6)
+      end
+
+      it 'unreachable discount, and lower quantity discount applies to invoice_item well above threshold' do
+        # Total Revenue => 15
+        setup_discount_example_4
+        expect(@invoice.total_revenue_with_discounts).to eq(15)
+      end
+
+      it 'multiple merchants on invoice, only one merchant has discounts' do
+        # Total Revenue => 35.1
+        setup_discount_example_5
+        expect(@invoice.total_revenue_with_discounts).to eq(35.1)
       end
     end
   end
@@ -126,7 +149,7 @@ RSpec.describe Invoice do
 
     @discount = create(:bulk_discount, threshold: 10, percent_discount: 50, merchant_id: @merchant.id)
 
-    # Result => item_1 discounted 20%
+    # Result => item_1 discounted 50%
     # Total Revenue => 10
   end
 


### PR DESCRIPTION
**What Changed**
- Complete all ActiveRecord-related issues (user stories)
  - Merchant invoice show page includes discounts in total revenue calculation, closes #7
  - Merchant invoice show page shows link to applied discounts next to invoice_items which had a discount, closes #8
  - Admin invoice show page includes discounts in total revenue calculation, closes #9
 
**Next Steps**
- Work on the API portion of the project

**Known Issues**
- Calculating total revenue for an invoice isn't efficient and uses some Ruby to get the calculation. I wonder if it can be changed to work more like `InvoiceItem.for_invoice_include_discount_id(...)`?