### PR TITLE
Show Upcoming Holidays on Merchant Bulk Discount Index

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -2,6 +2,7 @@ class BulkDiscountsController < ApplicationController
   def index
     @bulk_discounts = BulkDiscount.for_merchant(params[:merchant_id])
     @merchant_id = params[:merchant_id]
+    @upcoming_holidays = HolidayService.upcoming_holidays
   end
 
   def show

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -8,6 +8,6 @@ class InvoicesController < ApplicationController
     @merchant = Merchant.find(params[:merchant_id])
     invoice_id = params[:id]
     @invoice = Invoice.find(invoice_id)
-    @invoice_items = InvoiceItem.for_invoice_include_discount_id(invoice_id) # find_all_by_invoice(invoice_id)
+    @invoice_items = InvoiceItem.for_invoice_include_discount_id(invoice_id)
   end
 end

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,18 @@
+class Holiday
+  attr_reader :name, :date
+
+  def initialize(data)
+    @name = data[:localName]
+    @date = Date.parse(data[:date])
+  end
+
+  def pretty_date
+    @date.strftime('%A, %B %d, %Y')
+  end
+
+  def self.create_holidays_from(holidays_data)
+    holidays_data.map do |holiday_data|
+      new(holiday_data)
+    end
+  end
+end

--- a/app/services/api_service.rb
+++ b/app/services/api_service.rb
@@ -1,6 +1,3 @@
-# require 'faraday'
-# require 'pry'
-# require 'json'
 require 'repo'
 require 'contributor'
 require 'pull'
@@ -8,6 +5,7 @@ require 'commit'
 
 class ApiService
 
+  require "pry"; binding.pry
   def self.get_info(uri)
     response = Faraday.get("https://api.github.com/repos/avjohnston/little-esty-shop#{uri}")
     parsed = JSON.parse(response.body, symbolize_names: true)

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,19 @@
+class HolidayService
+  ENDPOINTS = {
+    base_url: 'https://date.nager.at',
+    next_public_holidays_uri: '/Api/v2/NextPublicHolidays/US'
+  }
+
+  def self.upcoming_holidays
+    holidays_data = get_info(ENDPOINTS[:next_public_holidays_uri])
+
+    Holiday.create_holidays_from(holidays_data[0..2])
+  end
+
+  private
+  def self.get_info(uri)
+    response = Faraday.get("#{ENDPOINTS[:base_url]}#{uri}")
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Your Bulk Discounts</h1>
 
 <section id='upcoming-holidays'>
-  <h3>Upcomint Holidays</h3>
+  <h3>Upcoming Holidays</h3>
   <% @upcoming_holidays.each do |holiday| %>
     <div class='holiday'>
       <p><%= "#{holiday.name} on #{holiday.pretty_date}" %>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,5 +1,15 @@
 <h1>Your Bulk Discounts</h1>
 
+<section id='upcoming-holidays'>
+  <h3>Upcomint Holidays</h3>
+  <% @upcoming_holidays.each do |holiday| %>
+    <div class='holiday'>
+      <p><%= "#{holiday.name} on #{holiday.pretty_date}" %>
+    </div>
+  <% end %>
+  <hr>
+</section>
+
 <div id='discounts'>
   <%= link_to 'Create New Discount', new_merchant_bulk_discount_path(@merchant_id) %>
   <% @bulk_discounts.each do |discount| %>

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -76,5 +76,13 @@ RSpec.describe 'Merchant bulk discount index page' do
       expect(current_path).to eq(merchant_bulk_discounts_path(@merchant))
       expect(page).to_not have_selector("#discount-#{@discount_1.id}")
     end
+
+    it 'shows next 3 upcoming US holidays' do
+      visit merchant_bulk_discounts_path(@merchant)
+
+      within('#upcoming-holidays') do
+        expect(page.all('.holiday').size).to eq(3)
+      end
+    end
   end
 end


### PR DESCRIPTION
**What Changed**
- Use [Nager.Date API](https://date.nager.at/swagger/index.html) to add list of next 3 holidays to merchant's bulk discount index, closes #2 

**Next Steps**
- Code cleanup

**Known Issues**
- Still no thorough testing of the API (e.g. with webmock)